### PR TITLE
归类+署名

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,50 +4,79 @@
 ----
 
 ### A
-* [angularjs-style-guide](https://github.com/johnpapa/angular-styleguide)
-* [angularjs-style-guide](https://github.com/gocardless/angularjs-style-guide)
-* [angularjs-style-guide](https://github.com/mgechev/angularjs-style-guide)
+
+* Angular
+    + [johnpapa/angularjs-style-guide](https://github.com/johnpapa/angular-styleguide)
+    + [gocardless/angularjs-style-guide](https://github.com/gocardless/angularjs-style-guide)
+    + [mgechev/angularjs-style-guide](https://github.com/mgechev/angularjs-style-guide)
 
 ### B
-* [bash-style-guide](https://github.com/bahamas10/bash-style-guide)
-* [Style-Guide-Boilerplate](https://github.com/bjankord/Style-Guide-Boilerplate)
+
+* Bash
+    + [bahamas10/bash-style-guide](https://github.com/bahamas10/bash-style-guide)
+* Boilerplate for build style guide
+    + [bjankord/Style-Guide-Boilerplate](https://github.com/bjankord/Style-Guide-Boilerplate)
 
 ### C
-* [coffeescript-style-guide](https://github.com/polarmobile/coffeescript-style-guide)
-* [clojure-style-guide](https://github.com/bbatsov/clojure-style-guide)
+
+* Coffee
+    + [polarmobile/coffeescript-style-guide](https://github.com/polarmobile/coffeescript-style-guide)
+
+* Clojure
+    + [bbatsov/clojure-style-guide](https://github.com/bbatsov/clojure-style-guide)
 
 ### E
-* [elasticsearch-definitive-guide](https://github.com/GavinFoo/elasticsearch-definitive-guide)
+
+* Elasticsearch
+    + [GavinFoo/elasticsearch-definitive-guide](https://github.com/GavinFoo/elasticsearch-definitive-guide)
 
 ### G
-* [git-style-guide](https://github.com/agis-/git-style-guide)
+
+* Git
+    + [agis-/git-style-guide](https://github.com/agis-/git-style-guide)
 
 ### H
-* [http-api-guide](https://github.com/bolasblack/http-api-guide)
+
+* RESTful API
+    + [bolasblack/http-api-guide](https://github.com/bolasblack/http-api-guide)
 
 ### J
-* [javascript-style-guide](https://github.com/adamlu/javascript-style-guide)
-* [javascript](https://github.com/airbnb/javascript)
+
+* Javascript
+    + [adamlu/javascript-style-guide](https://github.com/adamlu/javascript-style-guide)
+    + [airbnb/javascript](https://github.com/airbnb/javascript)
 
 ### N
-* [node-style-guide](https://github.com/felixge/node-style-guide)
+
+* Nodejs
+    + [felixge/node-style-guide](https://github.com/felixge/node-style-guide)
 
 ### O
-* [objective-c-style-guide](https://github.com/github/objective-c-style-guide)
-* [objective-c-style-guide](https://github.com/raywenderlich/objective-c-style-guide)
-* [objective-c-style-guide](https://github.com/NYTimes/objective-c-style-guide)
+
+* Objective-C
+    + [github/objective-c-style-guide](https://github.com/github/objective-c-style-guide)
+    + [raywenderlich/objective-c-style-guide](https://github.com/raywenderlich/objective-c-style-guide)
+    + [NYTimes/objective-c-style-guide](https://github.com/NYTimes/objective-c-style-guide)
 
 ### P
-* [php-fig-standards](https://github.com/php-fig/fig-standards)
-* [python-guide](https://github.com/kennethreitz/python-guide)
+
+* PHP
+    + [php-fig/php-fig-standards](https://github.com/php-fig/fig-standards)
+    + [kennethreitz/python-guide](https://github.com/kennethreitz/python-guide)
 
 ### R
-* [ruby-style-guide](https://github.com/bbatsov/ruby-style-guide)
-* [ruby-style-guide](https://github.com/airbnb/ruby)
+
+* Ruby
+    + [bbatsov/ruby-style-guide](https://github.com/bbatsov/ruby-style-guide)
+    + [airbnb/ruby-style-guide](https://github.com/airbnb/ruby)
 
 ### S
-* [swift-style-guide](https://github.com/raywenderlich/swift-style-guide)
-* [swift-style-guide](https://github.com/github/swift-style-guide)
+
+* Swift
+    + [raywenderlich/swift-style-guide](https://github.com/raywenderlich/swift-style-guide)
+    + [github/swift-style-guide](https://github.com/github/swift-style-guide)
 
 ### W
-* [wp-style-guide](https://github.com/helenhousandi/wp-style-guide)
+
+* WordPress
+    + [helenhousandi/wp-style-guide](https://github.com/helenhousandi/wp-style-guide)


### PR DESCRIPTION
今早我在看的时候有几个我就不太很直白的看出来它是干嘛的，所以作了一些修改供参考：
- 通常很多GitHub repo的命名容易相同，所以对外大家都加上用户名前缀。
- 语言或者工具名称归类更容易查找与识别它的作用
